### PR TITLE
DTSPO-15909 migrated Application Insights

### DIFF
--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=DTSPO-15909-Migrate-to-workspace-AI"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
   env     = var.env
   product = var.product

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,13 +1,14 @@
 module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
-  env     = var.env
-  product = var.product
-  name    = "${var.department}-api-mgmt"
+  env                   = var.env
+  product               = var.product
+  name                  = "${var.department}-api-mgmt"
 
-  resource_group_name = var.virtual_network_resource_group
+  resource_group_name   = var.virtual_network_resource_group
+  application_type      = "other"
 
-  common_tags = var.common_tags
+  common_tags           = var.common_tags
 }
 
 moved {

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -3,14 +3,14 @@ module "application_insights" {
 
   env     = var.env
   product = var.product
-  name    = "${var.product}-${var.component}-appinsights"
+  name    = "${var.department}-api-mgmt-appinsights"
 
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = var.virtual_network_resource_group
 
   common_tags = var.common_tags
 }
 
 moved {
-  from = azurerm_application_insights.appinsights
+  from = azurerm_application_insights.apim
   to   = module.application_insights.azurerm_application_insights.this
 }

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -3,7 +3,7 @@ module "application_insights" {
 
   env     = var.env
   product = var.product
-  name    = "${var.department}-api-mgmt-appinsights"
+  name    = "${var.department}-api-mgmt"
 
   resource_group_name = var.virtual_network_resource_group
 

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,8 +1,16 @@
-resource "azurerm_application_insights" "apim" {
-  name                = local.name
-  location            = var.location
-  resource_group_name = var.virtual_network_resource_group
-  application_type    = "other"
-  retention_in_days   = 30
-  tags                = var.common_tags
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}-${var.component}-appinsights"
+
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = var.common_tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=DTSPO-15909-Migrate-to-workspace-AI"
 
   env     = var.env
   product = var.product

--- a/main.tf
+++ b/main.tf
@@ -100,9 +100,9 @@ resource "azurerm_api_management_logger" "apim" {
   name                = "${local.name}-logger"
   api_management_name = azurerm_api_management.apim.name
   resource_group_name = var.virtual_network_resource_group
-  resource_id         = azurerm_application_insights.apim.id
+  resource_id         = module.application_insights.id
 
   application_insights {
-    instrumentation_key = azurerm_application_insights.apim.instrumentation_key
+    instrumentation_key = module.application_insights.instrumentation_key
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,7 @@ variable "location" {
   default = "uksouth"
 }
 
+variable "environment" {}
 variable "env" {}
 variable "product" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "location" {
-  default = "UK South"
+  default = "uksouth"
 }
 
 variable "environment" {}

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,8 @@ variable "location" {
   default = "uksouth"
 }
 
-variable "environment" {}
+variable "env" {}
+variable "product" {}
 
 variable "virtual_network_resource_group" {}
 


### PR DESCRIPTION
### Jira link (if applicable)

[tools.hmcts.net/jira/browse/DTSPO-15909](https://tools.hmcts.net/jira/browse/DTSPO-15909)

### Change description ###

Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using [hmcts/app-insights-migration-tool](https://github.com/hmcts/app-insights-migration-tool) as Classic Application Insights will deprecated and will be retired in February 2024.