### PR TITLE
DTSPO-15909-Migrate-to-workspace-AI-2

### DIFF
--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,7 +1,7 @@
 module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
-  env                   = local.env
+  env                   = local.environment
   product               = var.department
   name                  = "${var.department}-api-mgmt"
 

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,8 +1,8 @@
 module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
-  env                   = var.env
-  product               = var.product
+  env                   = local.env
+  product               = var.department
   name                  = "${var.department}-api-mgmt"
 
   resource_group_name   = var.virtual_network_resource_group


### PR DESCRIPTION

Jira link (if applicable)
[tools.hmcts.net/jira/browse/DTSPO-15909](https://tools.hmcts.net/jira/browse/DTSPO-15909)

Change description
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using [hmcts/app-insights-migration-tool](https://github.com/hmcts/app-insights-migration-tool) as Classic Application Insights will deprecated and will be retired in February 2024.