### PR TITLE
Update module to accept additional routes

### DIFF
--- a/route_table.tf
+++ b/route_table.tf
@@ -18,7 +18,7 @@ resource "azurerm_route" "additional_routes" {
   for_each = { for route in var.apim_additional_routes : route.name => route }
 
   name                   = lower(each.value.name)
-  route_table_name       = azurerm_route_table.route_table[0].name
+  route_table_name       = azurerm_route_table.route_table.name
   resource_group_name    = var.virtual_network_resource_group
   address_prefix         = each.value.address_prefix
   next_hop_type          = each.value.next_hop_type

--- a/route_table.tf
+++ b/route_table.tf
@@ -14,6 +14,17 @@ resource "azurerm_route" "default_route" {
   next_hop_in_ip_address = var.route_next_hop_in_ip_address
 }
 
+resource "azurerm_route" "additional_routes" {
+  for_each = { for route in var.apim_additional_routes : route.name => route }
+
+  name                   = lower(each.value.name)
+  route_table_name       = azurerm_route_table.route_table[0].name
+  resource_group_name    = var.virtual_network_resource_group
+  address_prefix         = each.value.address_prefix
+  next_hop_type          = each.value.next_hop_type
+  next_hop_in_ip_address = each.value.next_hop_in_ip_address
+}
+
 resource "azurerm_route" "azure_control_plane" {
   name                = "azure-control-plane"
   route_table_name    = azurerm_route_table.route_table.name

--- a/route_table.tf
+++ b/route_table.tf
@@ -15,7 +15,7 @@ resource "azurerm_route" "default_route" {
 }
 
 resource "azurerm_route" "additional_routes" {
-  for_each = { for route in var.apim_additional_routes : route.name => route }
+  for_each = { for route in var.additional_routes_apim : route.name => route }
 
   name                   = lower(each.value.name)
   route_table_name       = azurerm_route_table.route_table.name

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "route_next_hop_in_ip_address" {
   default = "10.10.1.1"
 }
 
-variable "apim_additional_routes" {
+variable "additional_routes_apim" {
   description = "A list of additional route configurations"
   type = list(object({
     name                   = string

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,14 @@ variable "route_next_hop_type" {
 variable "route_next_hop_in_ip_address" {
   default = "10.10.1.1"
 }
+
+variable "apim_additional_routes" {
+  description = "A list of additional route configurations"
+  type = list(object({
+    name                   = string
+    address_prefix         = string
+    next_hop_type          = string
+    next_hop_in_ip_address = string
+  }))
+  default = []
+}


### PR DESCRIPTION
Lets us define additional routes only if defined, but sets default as no extras so it's not blocking

Example: https://github.com/hmcts/sds-azure-platform/pull/835