### PR TITLE
Fix add alert location

### DIFF
--- a/app-insights.tf
+++ b/app-insights.tf
@@ -4,6 +4,7 @@ module "application_insights" {
   env     = local.environment
   product = var.department
   name    = "${var.department}-api-mgmt"
+  alert_location = var.alert_location
 
   resource_group_name = var.virtual_network_resource_group
   application_type    = "other"

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,9 +1,10 @@
 module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
-  env     = local.environment
-  product = var.department
-  name    = "${var.department}-api-mgmt"
+  env            = local.environment
+  product        = var.department
+  name           = "${var.department}-api-mgmt"
+  alert_location = "global"
 
   resource_group_name = var.virtual_network_resource_group
   application_type    = "other"

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=fix-test-app-insight-location"
 
   env     = local.environment
   product = var.department

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,5 +1,5 @@
 module "application_insights" {
-  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=fix-test-app-insight-location"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
   env     = local.environment
   product = var.department

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,10 +1,9 @@
 module "application_insights" {
-  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
+  source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=4.x"
 
   env     = local.environment
   product = var.department
   name    = "${var.department}-api-mgmt"
-  alert_location = var.alert_location
 
   resource_group_name = var.virtual_network_resource_group
   application_type    = "other"

--- a/app-insights.tf
+++ b/app-insights.tf
@@ -1,10 +1,9 @@
 module "application_insights" {
   source = "git::https://github.com/hmcts/terraform-module-application-insights?ref=main"
 
-  env            = local.environment
-  product        = var.department
-  name           = "${var.department}-api-mgmt"
-  alert_location = "global"
+  env     = local.environment
+  product = var.department
+  name    = "${var.department}-api-mgmt"
 
   resource_group_name = var.virtual_network_resource_group
   application_type    = "other"

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_api_management" "apim" {
     type = "SystemAssigned"
   }
 
-  zones = local.zones
+  zones                = local.zones
   public_ip_address_id = azurerm_public_ip.apim.id
 
   sku_name = local.sku_name

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,6 @@ variable "location" {
   default = "uksouth"
 }
 
-variable "alert_location" {
-  default     = "global"
-}
-
 variable "environment" {}
 
 variable "virtual_network_resource_group" {}
@@ -51,10 +47,4 @@ variable "additional_routes_apim" {
     next_hop_in_ip_address = string
   }))
   default = []
-}
-
-variable "alert_location" {
-  description = "Target Azure location to deploy the alert"
-  type        = string
-  default     = "global"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,6 @@ variable "location" {
   default = "uksouth"
 }
 
-variable alert_location {
-  default = "global"
-}
-
 variable "environment" {}
 
 variable "virtual_network_resource_group" {}

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,8 @@ variable "location" {
   default = "uksouth"
 }
 
+variable alert_location {}
+
 variable "environment" {}
 
 variable "virtual_network_resource_group" {}

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,9 @@ variable "location" {
   default = "uksouth"
 }
 
-variable alert_location {}
+variable alert_location {
+  default = "global"
+}
 
 variable "environment" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,9 @@ variable "additional_routes_apim" {
   }))
   default = []
 }
+
+variable "alert_location" {
+  description = "Target Azure location to deploy the alert"
+  type        = string
+  default     = "global"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,10 @@ variable "location" {
   default = "uksouth"
 }
 
+variable "alert_location" {
+  default     = "global"
+}
+
 variable "environment" {}
 
 variable "virtual_network_resource_group" {}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24542

### Change description
Change branch reference for the app insights module from `main` to `4.x` to fix the pipeline errors bubbling up from within that sub-module, throught this module and into the `sds-azure-platform` pipeline as seen here: LINK
The error is about a missing `location` required parameter on the `azurerm_monitor_activity_log_alert` resource.
Looks like this has been fixed on `4.x` with a customisable parameter that also contains a default `global` value.
Furthermore, `4.x` appears to be listed as the default branch on github instead of `main`.

### Testing done
Tested on sds-azure-platform pipeline runs:
- Failure on master: 
- Fixed using this branch as ref for the module: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=768169&view=results 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
