### PR TITLE
 fix: adding logic to enable a certificate lookup for api.hmcts.net

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -7,7 +7,7 @@ data "azurerm_key_vault" "main" {
 }
 
 data "azurerm_key_vault_certificate" "certificate" {
-  name         = (local.key_vault_environment == "prod") ? "wildcard-platform-hmcts-net" : "wildcard-${local.key_vault_environment}-platform-hmcts-net"
+  name         = (local.key_vault_environment == "prod") ? "wildcard-${var.cert_domain}-hmcts-net" : "wildcard-${local.key_vault_environment}-${var.cert_domain}-hmcts-net"
   key_vault_id = data.azurerm_key_vault.main.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,10 @@ variable "disable_trusted_service_connectivity" {
   default     = false
 }
 
+variable "cert_domain" {
+  default = "platform"
+}
+
 variable "custom_nsg_rules" {
   description = "A map of custom NSG rules to apply in addition to the default rules"
   type = map(object({


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32492

### Change description

Adding more logic to this module for handling certificates that do not reside in the platform.hmcts.net domain. i.e. api.hmcts.net

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
