### PR TITLE
Update module to allow use of UAMI and custom gateway hostnames

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -18,3 +18,9 @@ data "azapi_resource" "apim_custom_properties" {
 
   depends_on = [azurerm_api_management.apim]
 }
+
+data "azurerm_user_assigned_identity" "uami" {
+  count               = var.user_assigned_managed_identity_name != null ? 1 : 0
+  name                = var.user_assigned_managed_identity_name
+  resource_group_name = var.user_assigned_managed_identity_resource_group
+}

--- a/data.tf
+++ b/data.tf
@@ -1,14 +1,16 @@
 data "azurerm_client_config" "current" {}
 
 data "azurerm_key_vault" "main" {
+  count               = var.certificate_secret_id == null ? 1 : 0
   provider            = azurerm.acmedcdcftapps
   name                = "acme${local.acmekv}${local.acme_environment}"
   resource_group_name = "${var.department}-platform-${local.acme_environment}-rg"
 }
 
 data "azurerm_key_vault_certificate" "certificate" {
+  count        = var.certificate_secret_id == null ? 1 : 0
   name         = (local.key_vault_environment == "prod") ? "wildcard-${var.cert_domain}-hmcts-net" : "wildcard-${local.key_vault_environment}-${var.cert_domain}-hmcts-net"
-  key_vault_id = data.azurerm_key_vault.main.id
+  key_vault_id = data.azurerm_key_vault.main[0].id
 }
 
 data "azapi_resource" "apim_custom_properties" {

--- a/init.tf
+++ b/init.tf
@@ -28,7 +28,7 @@ locals {
 
   key_vault_environment = (var.environment == "sbox") ? "sandbox" : (var.environment == "stg") ? "staging" : var.environment
 
-  cert_url = replace(data.azurerm_key_vault_certificate.certificate.secret_id, "/${data.azurerm_key_vault_certificate.certificate.version}", "")
+  cert_url = var.certificate_secret_id != null ? var.certificate_secret_id : replace(data.azurerm_key_vault_certificate.certificate[0].secret_id, "/${data.azurerm_key_vault_certificate.certificate[0].version}", "")
   criticality = {
     sbox     = "Low"
     aat      = "High"

--- a/init.tf
+++ b/init.tf
@@ -12,7 +12,7 @@ terraform {
 }
 
 locals {
-  name = "${var.department}-api-mgmt-${local.environment}"
+  name = var.custom_name != null ? var.custom_name : "${var.department}-api-mgmt-${local.environment}"
   # platform_api_mgmt_sku = var.environment == "prod" ? "Premium_1" : "Developer_1"
 
   environment = (var.environment == "aat") ? "stg" : (var.environment == "sandbox") ? "sbox" : "${(var.environment == "perftest") ? "test" : "${var.environment}"}"

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "azurerm_api_management" "apim" {
 resource "azurerm_role_assignment" "apim" {
   count                = var.user_assigned_managed_identity_name != null ? 0 : 1
   principal_id         = azurerm_api_management.apim.identity[0].principal_id
-  scope                = data.azurerm_key_vault.main.id
+  scope                = data.azurerm_key_vault.main[0].id
   role_definition_name = "Key Vault Secrets User"
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -5,11 +5,11 @@ data "azurerm_subnet" "api-mgmt-subnet" {
 }
 
 resource "azurerm_public_ip" "apim" {
-  name                = "${var.department}-api-mgmt-${var.environment}-private-pip"
+  name                = var.custom_name != null ? "${var.custom_name}-private-pip" : "${var.department}-api-mgmt-${var.environment}-private-pip"
   resource_group_name = var.virtual_network_resource_group
   location            = var.location
   allocation_method   = "Static"
-  domain_name_label   = "${var.department}-api-mgmt-${var.environment}-pip"
+  domain_name_label   = var.custom_name != null ? "${var.custom_name}-pip" : "${var.department}-api-mgmt-${var.environment}-pip"
   zones               = local.zones
 
   tags = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,9 @@ resource "azurerm_api_management" "apim" {
   tags = var.common_tags
 
   depends_on = [
-    azurerm_public_ip.apim
+    azurerm_public_ip.apim,
+    azurerm_subnet_network_security_group_association.apim,
+    azurerm_subnet_route_table_association.api-mgmt-subnet
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,8 @@ resource "azurerm_api_management" "apim" {
   }
 
   identity {
-    type = "SystemAssigned"
+    type         = var.user_assigned_managed_identity_name != null ? "UserAssigned" : "SystemAssigned"
+    identity_ids = var.user_assigned_managed_identity_name != null ? [data.azurerm_user_assigned_identity.uami[0].id] : []
   }
 
   zones                = local.zones
@@ -52,9 +53,9 @@ resource "azurerm_api_management" "apim" {
 }
 
 resource "azurerm_role_assignment" "apim" {
-  principal_id = azurerm_api_management.apim.identity[0].principal_id
-  scope        = data.azurerm_key_vault.main.id
-
+  count                = var.user_assigned_managed_identity_name != null ? 0 : 1
+  principal_id         = azurerm_api_management.apim.identity[0].principal_id
+  scope                = data.azurerm_key_vault.main.id
   role_definition_name = "Key Vault Secrets User"
 
   depends_on = [
@@ -62,28 +63,40 @@ resource "azurerm_role_assignment" "apim" {
   ]
 }
 
+// Required to stop resource recreation for existing apim sami use
+moved {
+  from = azurerm_role_assignment.apim
+  to   = azurerm_role_assignment.apim[0]
+}
+
 resource "azurerm_api_management_custom_domain" "api-management-custom-domain" {
   api_management_id = azurerm_api_management.apim.id
 
-  gateway {
-    host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-api-mgmt.platform.hmcts.net" : "${var.department}-api-mgmt.${local.key_vault_environment}.platform.hmcts.net"
-    key_vault_id                 = local.cert_url
-    negotiate_client_certificate = true
-    default_ssl_binding          = true
-  }
-
-  gateway {
-    host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-api-mgmt-appgw.platform.hmcts.net" : "${var.department}-api-mgmt-appgw.${local.key_vault_environment}.platform.hmcts.net"
-    key_vault_id                 = local.cert_url
-    negotiate_client_certificate = true
-    default_ssl_binding          = true
-  }
-
-  gateway {
-    host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-mtls-api-mgmt-appgw.platform.hmcts.net" : "${var.department}-mtls-api-mgmt-appgw.${local.key_vault_environment}.platform.hmcts.net"
-    key_vault_id                 = local.cert_url
-    negotiate_client_certificate = true
-    default_ssl_binding          = true
+  dynamic "gateway" {
+    for_each = var.custom_gateway_hostnames != null ? var.custom_gateway_hostnames : [
+      {
+        host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-api-mgmt.platform.hmcts.net" : "${var.department}-api-mgmt.${local.key_vault_environment}.platform.hmcts.net"
+        negotiate_client_certificate = true
+        default_ssl_binding          = true
+      },
+      {
+        host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-api-mgmt-appgw.platform.hmcts.net" : "${var.department}-api-mgmt-appgw.${local.key_vault_environment}.platform.hmcts.net"
+        negotiate_client_certificate = true
+        default_ssl_binding          = true
+      },
+      {
+        host_name                    = (local.key_vault_environment == "prod") ? "${var.department}-mtls-api-mgmt-appgw.platform.hmcts.net" : "${var.department}-mtls-api-mgmt-appgw.${local.key_vault_environment}.platform.hmcts.net"
+        negotiate_client_certificate = true
+        default_ssl_binding          = true
+      }
+    ]
+    content {
+      host_name                       = gateway.value.host_name
+      key_vault_id                    = local.cert_url
+      negotiate_client_certificate    = gateway.value.negotiate_client_certificate
+      default_ssl_binding             = gateway.value.default_ssl_binding
+      ssl_keyvault_identity_client_id = var.user_assigned_managed_identity_name != null ? data.azurerm_user_assigned_identity.uami[0].client_id : null
+    }
   }
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,12 @@ variable "certificate_secret_id" {
   default     = null
 }
 
+variable "custom_name" {
+  description = "Overrides the derived instance name (department-api-mgmt-environment) used for the APIM service, public IP, NSG, route table and logger. Defaults to null (the derived name). Use when a distinct name is needed — e.g. a second APIM in a department that already owns the derived name. Does not affect department-driven vault/subscription/prefix selection."
+  type        = string
+  default     = null
+}
+
 variable "custom_gateway_hostnames" {
   description = "List of custom gateway hostnames. If not provided, defaults to the standard department-based naming."
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -55,8 +55,30 @@ variable "disable_trusted_service_connectivity" {
   default     = false
 }
 
+variable "user_assigned_managed_identity_name" {
+  description = "The name of a User Assigned Managed Identity to assign to the API Management Service. If not provided, only SystemAssigned identity is used."
+  type        = string
+  default     = null
+}
+
+variable "user_assigned_managed_identity_resource_group" {
+  description = "The resource group of the User Assigned Managed Identity. Required when user_assigned_managed_identity_name is set."
+  type        = string
+  default     = null
+}
+
 variable "cert_domain" {
   default = "platform"
+}
+
+variable "custom_gateway_hostnames" {
+  description = "List of custom gateway hostnames. If not provided, defaults to the standard department-based naming."
+  type = list(object({
+    host_name                    = string
+    negotiate_client_certificate = optional(bool, true)
+    default_ssl_binding          = optional(bool, true)
+  }))
+  default = null
 }
 
 variable "custom_nsg_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "cert_domain" {
   default = "platform"
 }
 
+variable "certificate_secret_id" {
+  description = "Versionless Key Vault secret ID of the gateway certificate. When set, it is used directly as the custom domain key_vault_id and the department-derived vault/certificate lookup is skipped. The certificate is fetched at runtime via the UAMI, which must have Key Vault Secrets User on the source vault."
+  type        = string
+  default     = null
+}
+
 variable "custom_gateway_hostnames" {
   description = "List of custom gateway hostnames. If not provided, defaults to the standard department-based naming."
   type = list(object({


### PR DESCRIPTION
- Adds support for user to bring their own UAMI for independent lifecycles as per MS for APIM: 
```
For disaster recovery, set up API Management with a user-assigned managed identity instead of a system-assigned identity. If you redeploy or delete the resource, the identity and its permissions remain in place, so you can restore access more easily. Use Azure Pipelines to automate backups. Decide if you need to deploy your services in more than one region for better reliability. 
 ```

- Consumers now able to provide `user_assigned_managed_identity_name` , `user_assigned_managed_identity_resource_group` for UAMI use
- Adds support to add fully custom gateway hostnames from inputs instead of hardcoded formatting by providing `custom_gateway_hostnames`
- Consumer can now add role assignments independently of APIM lifecycle and should add `"Key Vault Secrets User"` to the required key vault for any certificate requirements beforehand


> [!NOTE]  
> Validated for non-breaking changes in [sds-azure-platform](https://github.com/hmcts/sds-azure-platform/pull/1124) and [azure-platform-terraform](https://github.com/hmcts/azure-platform-terraform/pull/3018) that this does not introduce changes besides a state file move which would happen on subsequent applies on a one-off basis:
```
  # module.api-mgmt.azurerm_role_assignment.apim has moved to module.api-mgmt.azurerm_role_assignment.apim[0]
    resource "azurerm_role_assignment" "apim" {
        id                                     = "..."
        name                                   = ".."
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.

```